### PR TITLE
Test pinning cuda versions

### DIFF
--- a/nvidia-ubuntu/uptodate.yaml
+++ b/nvidia-ubuntu/uptodate.yaml
@@ -1,4 +1,5 @@
 dockerbuild:
+
   build_args:
     cuda_version:
       key: cuda

--- a/ubuntu/cuda/uptodate.yaml
+++ b/ubuntu/cuda/uptodate.yaml
@@ -1,20 +1,16 @@
 dockerbuild:
-  build_args:
+  matrix:
     cuda_version:
-      key: cuda
-      versions:
        - "10.1.243"
        - "11.0.3"
        - "11.1.1"
        - "11.2.2"
        - "11.3.1"
        - "11.4.0"
-
-    # Look for ubuntu versions for our base builds
     ubuntu_version:
-      key: ubuntu
-      name: ghcr.io/rse-ops/ubuntu
-      type: container
-      startat: "20.04"
-      filter: 
-        - "^[0-9]+[.]04$"
+       - "18.04"
+       - "22.04"
+       - "22.04"
+       - "22.04"
+       - "22.04"
+       - "22.04"


### PR DESCRIPTION
We want cuda 10.x to build with ubuntu 18.04 and 11.x to use 22.04.

If this works it will close #48 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>