### PR TITLE
test fix for ubuntu 20.04

### DIFF
--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -46,7 +46,8 @@ RUN python3 -m pip install botocore boto3 && \
     spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
-RUN spack external find && \
+# We cannot do a global find because finding gettext will fail builds
+RUN spack external find gcc@11.0.1 autoconf bzip2 git tar xz perl && \
     spack config add 'packages:all:target:[x86_64]' && \
     # Install a new CMake
     spack install cmake@3.20.4

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -47,7 +47,7 @@ RUN python3 -m pip install botocore boto3 && \
 
 # Find packages already installed on system, e.g. autoconf
 # We cannot do a global find because finding gettext will fail builds
-RUN spack external find gcc@11.0.1 autoconf bzip2 git tar xz perl && \
+RUN spack external find gcc autoconf bzip2 git tar xz perl && \
     spack config add 'packages:all:target:[x86_64]' && \
     # Install a new CMake
     spack install cmake@3.20.4


### PR DESCRIPTION
Spack yesterday merged a pr that adds external find for gettext, and this is what is failing our builds. the fix here is to be explicit about what we are allowing to find

Signed-off-by: vsoch <vsoch@users.noreply.github.com>