### PR TITLE
link llvm lib dynamically and use split dwarf for smaller images

### DIFF
--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install llvm with spack
 ARG llvm_version
 ENV llvm_version=$llvm_version
+ENV llvm_spec=$llvm_version+llvm_dylib+link_llvm_dylib+split_dwarf
 
 RUN spack install llvm@${llvm_version}
 RUN spack view --dependencies no symlink --ignore-conflicts /opt/view llvm@${llvm_version} && \

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -4,8 +4,8 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install llvm with spack
 ARG llvm_version
 ENV llvm_version=$llvm_version
-ENV llvm_spec=$llvm_version+llvm_dylib+link_llvm_dylib+split_dwarf
+ENV llvm_spec=llvm@${llvm_version}+llvm_dylib+link_llvm_dylib+split_dwarf~lldb
 
-RUN spack install llvm@${llvm_version}
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view llvm@${llvm_version} && \
+RUN spack install ${llvm_spec}
+RUN spack view --dependencies no symlink --ignore-conflicts /opt/view ${llvm_spec} && \
   spack compiler find


### PR DESCRIPTION
This will make llvm compile faster, take up less space, and skip building lldb.  Building llvm 10.0.0 for ubuntu 22.04 went from 7.36gb to 3.05gb.  It isn't even building with MinSizeRel, but this seems like a solid win.