### PR TITLE
reuse dependencies, clean up apt cache

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -4,7 +4,7 @@ set -e
 
 basedir=$(dirname ${result_name})
 printf "Base directory is ${basedir}\n"
-dockerfile=$(basename ${result_name})
+dockerfile=${result_name}
 printf "Dockerfile basename is ${dockerfile}\n"
 tag=$(basename ${basedir})
 printf "Tag is ${tag}\n"

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -11,7 +11,6 @@ printf "Tag is ${tag}\n"
 container=$(basename $(dirname $basedir))          
 printf "Container is ${container}\n"
 cat ${result_name}
-cd $basedir
 container_name=ghcr.io/rse-ops/${container}:${tag}
 docker pull ${container_name} || echo "Container $container_name does not exist yet"
 printf "docker build -f ${dockerfile} -t ${container_name} .\n"

--- a/scripts/apt-install-defaults-plus-args
+++ b/scripts/apt-install-defaults-plus-args
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+packages=(
+  # fetchers
+  ca-certificates
+  curl
+  git
+  wget
+  # interactive tools
+  valgrind
+  vim-nox
+  # build stuff
+  build-essential
+  dh-autoreconf
+  gnupg2
+  lcov
+  ninja-build
+  pkg-config
+  python3
+  python3-pip
+  python3-dev
+  sudo
+  xsltproc
+  # common build deps
+  libbinutils
+  binutils-dev
+  ncurses-bin
+  libncurses-dev
+  hwloc-nox
+  libhwloc-dev
+  libssl-dev
+)
+apt-get -qq update
+apt-get -qq install -fy tzdata
+apt-get -qq install -y --no-install-recommends "${packages[@]}" "$@"
+rm -rf /var/lib/apt/lists/*
+apt-get clean
+
+

--- a/scripts/install-cmake-binary
+++ b/scripts/install-cmake-binary
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-x86_64.sh > cmake.sh
+bash cmake.sh --prefix=/usr/local --skip-license
+rm cmake.sh

--- a/scripts/set-up-spack
+++ b/scripts/set-up-spack
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+pushd /opt
+
+git clone https://github.com/spack/spack spack
+pushd spack
+git reset --hard ${spack_commit}
+popd
+
+# temporary path update for this script
+export PATH=/opt/spack/bin:$PATH
+
+# Install Clingo for Spack
+python3 -m pip install --upgrade pip
+python3 -m pip install clingo
+
+# Use the autamus build cache for maybe faster install?
+python3 -m pip install botocore boto3
+spack mirror add autamus s3://autamus-cache
+curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub
+spack gpg trust key.pub
+
+# Find packages already installed on system, e.g. autoconf
+# IMPORTANT: ensure that all binaries installed include their development files
+#            failure to do this will get them detected, and kill builds with
+#            spack
+spack external find # NOTE no all
+# Find some packages out of the default check set that work
+spack external find python perl binutils git tar xz bzip2
+# configure spack
+# build for the generic target
+spack config add 'packages:all:target:[x86_64]'
+# reuse as much as possible, make externals useful
+spack config add 'concretizer:reuse:true'
+# avoid building an external cmake
+spack config add 'packages:cmake:buildable:False'
+# Generate spack environment for packages
+spack env create --dir /opt/env --with-view /opt/view
+
+# ensure clangs and others that don't inject rpaths make working executables
+echo /opt/view/lib > /etc/ld.so.conf.d/spack_view.conf
+echo /opt/view/lib64 > /etc/ld.so.conf.d/spack_view.conf
+ldconfig
+
+popd

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ./scripts /opt/scripts
+COPY ../../scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -7,46 +7,21 @@ ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
-      build-essential \
-      ca-certificates \
-      curl \
-      dh-autoreconf \
-      git \
-      gnupg2 \
-      libssl-dev \
-      ninja-build \
-      python-dev \ 
-      python3-pip \
-      python3-setuptools \
-      sudo \
-      valgrind \
-      vim \
-      wget
+WORKDIR /opt
+COPY ./scripts /opt/scripts
+RUN ./scripts/apt-install-defaults-plus-args
+ENV CMAKE=3.20.4
+RUN ./scripts/install-cmake-binary
 
 # Install spack
-WORKDIR /opt
-RUN git clone https://github.com/spack/spack && \
-    cd spack && \
-    git reset --hard ${spack_commit}
+RUN ./scripts/set-up-spack
 ENV PATH=/opt/spack/bin:$PATH
+# Tell spack to use this one without arguments
+ENV SPACK_ENV=/opt/env
 
-# Use the autamus build cache for maybe faster install?
-RUN python3 -m pip install botocore boto3 && \
-    spack mirror add autamus s3://autamus-cache && \
-    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
-    spack gpg trust key.pub
-
-# Find packages already installed on system, e.g. autoconf and install cmake
-RUN spack external find && \
-    spack config add 'packages:all:target:[x86_64]' && \
-    spack install cmake@3.20.4
-
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view cmake@3.20.4
+# Add appropriate paths pointing to the view
 ENV PATH=/opt/view/bin:$PATH
-
-RUN spack external find cmake && \
-    spack config add 'packages:cmake:buildable:False' && \
-    echo /opt/view/lib > /etc/ld.so.conf.d/spack_view.conf && \
-    ldconfig
+ENV MANPATH=/opt/view/share/man:$MANPATH
+ENV PKG_CONFIG_PATH=/opt/view/lib/pkgconfig:/opt/view/lib64/pkgconfig:/opt/view/share/pkgconfig:$PKG_CONFIG_PATH
+ENV CMAKE_PREFIX_PATH=/opt/view
+ENV ACLOCAL_PATH=/opt/view/share/aclocal

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ../../scripts /opt/scripts
+COPY ./scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -7,55 +7,21 @@ ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
-RUN apt-get -qq update && \
-    apt-get -qq install -fy tzdata && \
-    apt-get -qq install -y --no-install-recommends \
-      build-essential \
-      ca-certificates \
-      curl \
-      dh-autoreconf \
-      git \
-      gnupg2 \
-      lcov \
-      libssl-dev \
-      ninja-build \
-      pkg-config \
-      python-dev \ 
-      python3-pip \
-      sudo \
-      valgrind \
-      vim \
-      wget \
-      xsltproc
-
-# Install Clingo for Spack
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install clingo
+WORKDIR /opt
+COPY ./scripts /opt/scripts
+RUN ./scripts/apt-install-defaults-plus-args
+ENV CMAKE=3.20.4
+RUN ./scripts/install-cmake-binary
 
 # Install spack
-WORKDIR /opt
-RUN git clone https://github.com/spack/spack && \
-    cd spack && \
-    git reset --hard ${spack_commit}
+RUN ./scripts/set-up-spack
 ENV PATH=/opt/spack/bin:$PATH
+# Tell spack to use this one without arguments
+ENV SPACK_ENV=/opt/env
 
-# Use the autamus build cache for maybe faster install?
-RUN python3 -m pip install botocore boto3 && \
-    spack mirror add autamus s3://autamus-cache && \
-    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
-    spack gpg trust key.pub
-
-# Find packages already installed on system, e.g. autoconf
-# We cannot do a global find because finding gettext will fail builds
-RUN spack external find gcc autoconf bzip2 git tar xz perl && \
-    spack config add 'packages:all:target:[x86_64]' && \
-    # Install a new CMake
-    spack install cmake@3.20.4
-
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view cmake@3.20.4
+# Add appropriate paths pointing to the view
 ENV PATH=/opt/view/bin:$PATH
-
-RUN spack external find cmake && \
-    spack config add 'packages:cmake:buildable:False' && \
-    echo /opt/view/lib > /etc/ld.so.conf.d/spack_view.conf && \
-    ldconfig
+ENV MANPATH=/opt/view/share/man:$MANPATH
+ENV PKG_CONFIG_PATH=/opt/view/lib/pkgconfig:/opt/view/lib64/pkgconfig:/opt/view/share/pkgconfig:$PKG_CONFIG_PATH
+ENV CMAKE_PREFIX_PATH=/opt/view
+ENV ACLOCAL_PATH=/opt/view/share/aclocal

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ./scripts /opt/scripts
+COPY ../../scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ../../scripts /opt/scripts
+COPY ./scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ./scripts /opt/scripts
+COPY ../../scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -26,7 +26,11 @@ RUN apt-get -qq update && \
       valgrind \
       vim \
       wget \
-      xsltproc
+      xsltproc \
+      ncurses-bin \
+      libncurses-dev \
+      && rm -rf /var/lib/apt/lists/* \
+      && apt-get clean
 
 # Install Clingo for Spack
 RUN python3 -m pip install --upgrade pip && \
@@ -48,6 +52,7 @@ RUN python3 -m pip install botocore boto3 && \
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \
     spack config add 'packages:all:target:[x86_64]' && \
+    spack config add 'concretizer:reuse:true' && \
     # Install a new CMake
     spack install cmake@3.20.4
 

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -22,13 +22,17 @@ RUN apt-get -qq update && \
       pkg-config \
       python3 \
       python3-pip \
+      python3-dev \
       sudo \
       valgrind \
-      vim \
+      vim-nox \
       wget \
       xsltproc \
       ncurses-bin \
       libncurses-dev \
+      libbinutils-dev \
+      hwloc-nox \
+      libhwloc-dev \
       && rm -rf /var/lib/apt/lists/* \
       && apt-get clean
 
@@ -38,9 +42,10 @@ RUN python3 -m pip install --upgrade pip && \
 
 # Install spack
 WORKDIR /opt
-RUN git clone https://github.com/spack/spack && \
-    cd spack && \
+RUN git clone https://github.com/spack/spack spack-huge && \
+    pushd spack-huge && \
     git reset --hard ${spack_commit}
+
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?
@@ -49,17 +54,28 @@ RUN python3 -m pip install botocore boto3 && \
     curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
     spack gpg trust key.pub
 
-# Find packages already installed on system, e.g. autoconf
-RUN spack external find && \
-    spack config add 'packages:all:target:[x86_64]' && \
-    spack config add 'concretizer:reuse:true' && \
-    # Install a new CMake
-    spack install cmake@3.20.4
+ENV CMAKE=3.20.4
+RUN curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-x86_64.sh > cmake.sh ; \
+    bash cmake.sh --prefix=/usr/local --skip-license
 
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view cmake@3.20.4
+# Find packages already installed on system, e.g. autoconf
+RUN spack external find --all && \
+    spack config add 'packages:all:target:[x86_64]' && \
+    spack config add 'concretizer:reuse:true'
+
+# Generate spack environment for packages
+RUN spack env create --dir /opt/env --with-view /opt/view
+# Tell spack to use this one without arguments
+ENV SPACK_ENV=/opt/env
+# Add appropriate paths pointing to the view
 ENV PATH=/opt/view/bin:$PATH
+ENV MANPATH=/opt/view/share/man:$MANPATH
+ENV PKG_CONFIG_PATH=/opt/view/lib/pkgconfig:/opt/view/lib64/pkgconfig:/opt/view/share/pkgconfig:$PKG_CONFIG_PATH
+ENV CMAKE_PREFIX_PATH=/opt/view
+ENV ACLOCAL_PATH=/opt/view/share/aclocal
 
 RUN spack external find cmake && \
     spack config add 'packages:cmake:buildable:False' && \
     echo /opt/view/lib > /etc/ld.so.conf.d/spack_view.conf && \
+    echo /opt/view/lib64 > /etc/ld.so.conf.d/spack_view.conf && \
     ldconfig

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -7,77 +7,21 @@ ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
-RUN apt-get -qq update && \
-    apt-get -qq install -fy tzdata && \
-    apt-get -qq install -y --no-install-recommends \
-      build-essential \
-      ca-certificates \
-      curl \
-      dh-autoreconf \
-      git \
-      gnupg2 \
-      lcov \
-      libssl-dev \
-      ninja-build \
-      pkg-config \
-      python3 \
-      python3-pip \
-      python3-dev \
-      sudo \
-      valgrind \
-      vim-nox \
-      wget \
-      xsltproc \
-      ncurses-bin \
-      libncurses-dev \
-      libbinutils \
-      binutils-dev \
-      hwloc-nox \
-      libhwloc-dev \
-      && rm -rf /var/lib/apt/lists/* \
-      && apt-get clean
-
-# Install Clingo for Spack
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install clingo
+WORKDIR /opt
+COPY ./scripts /opt/scripts
+RUN ./scripts/apt-install-defaults-plus-args
+ENV CMAKE=3.20.4
+RUN ./scripts/install-cmake-binary
 
 # Install spack
-WORKDIR /opt
-RUN git clone https://github.com/spack/spack spack && \
-    cd spack && \
-    git reset --hard ${spack_commit}
-
+RUN ./scripts/set-up-spack
 ENV PATH=/opt/spack/bin:$PATH
-
-# Use the autamus build cache for maybe faster install?
-RUN python3 -m pip install botocore boto3 && \
-    spack mirror add autamus s3://autamus-cache && \
-    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
-    spack gpg trust key.pub
-
-ENV CMAKE=3.20.4
-RUN curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-x86_64.sh > cmake.sh ; \
-    bash cmake.sh --prefix=/usr/local --skip-license && \
-    rm cmake.sh
-
-# Find packages already installed on system, e.g. autoconf
-RUN spack external find --all && \
-    spack config add 'packages:all:target:[x86_64]' && \
-    spack config add 'concretizer:reuse:true'
-
-# Generate spack environment for packages
-RUN spack env create --dir /opt/env --with-view /opt/view
 # Tell spack to use this one without arguments
 ENV SPACK_ENV=/opt/env
+
 # Add appropriate paths pointing to the view
 ENV PATH=/opt/view/bin:$PATH
 ENV MANPATH=/opt/view/share/man:$MANPATH
 ENV PKG_CONFIG_PATH=/opt/view/lib/pkgconfig:/opt/view/lib64/pkgconfig:/opt/view/share/pkgconfig:$PKG_CONFIG_PATH
 ENV CMAKE_PREFIX_PATH=/opt/view
 ENV ACLOCAL_PATH=/opt/view/share/aclocal
-
-RUN spack external find cmake && \
-    spack config add 'packages:cmake:buildable:False' && \
-    echo /opt/view/lib > /etc/ld.so.conf.d/spack_view.conf && \
-    echo /opt/view/lib64 > /etc/ld.so.conf.d/spack_view.conf && \
-    ldconfig

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -qq update && \
       ncurses-bin \
       libncurses-dev \
       libbinutils \
+      binutils-dev \
       hwloc-nox \
       libhwloc-dev \
       && rm -rf /var/lib/apt/lists/* \

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get -qq update && \
       xsltproc \
       ncurses-bin \
       libncurses-dev \
-      libbinutils-dev \
+      libbinutils \
       hwloc-nox \
       libhwloc-dev \
       && rm -rf /var/lib/apt/lists/* \
@@ -42,8 +42,8 @@ RUN python3 -m pip install --upgrade pip && \
 
 # Install spack
 WORKDIR /opt
-RUN git clone https://github.com/spack/spack spack-huge && \
-    pushd spack-huge && \
+RUN git clone https://github.com/spack/spack spack && \
+    cd spack && \
     git reset --hard ${spack_commit}
 
 ENV PATH=/opt/spack/bin:$PATH
@@ -56,7 +56,8 @@ RUN python3 -m pip install botocore boto3 && \
 
 ENV CMAKE=3.20.4
 RUN curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-x86_64.sh > cmake.sh ; \
-    bash cmake.sh --prefix=/usr/local --skip-license
+    bash cmake.sh --prefix=/usr/local --skip-license && \
+    rm cmake.sh
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find --all && \

--- a/ubuntu/22.04/Dockerfile
+++ b/ubuntu/22.04/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
 WORKDIR /opt
-COPY ../../scripts /opt/scripts
+COPY ./scripts /opt/scripts
 RUN ./scripts/apt-install-defaults-plus-args
 ENV CMAKE=3.20.4
 RUN ./scripts/install-cmake-binary

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -9,19 +9,11 @@ ENV CC=/opt/view/bin/clang
 ENV CXX=/opt/view/bin/clang++
 ENV CPP=/opt/view/bin/clang-cpp
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
-      binutils-dev \
-      python3-dev \
-      && rm -rf /var/lib/apt/lists/* \
-      && apt-get clean
-
-RUN spack external find python perl binutils
-
-RUN spack -v install --reuse ${llvm_spec}
 # build compiler
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view ${llvm_spec} && \
-  spack compiler find
+RUN spack -v install --reuse ${llvm_spec}
+
+# add new compiler to spack
+RUN spack compiler find
 
 # set default for spack
 RUN spack config add "packages:all:compiler:[clang@${llvm_version}]"


### PR DESCRIPTION
A couple tweaks here that make this container very slightly smaller, maybe 100mb, but should reduce the size of downstream containers by substantially more by having spack re-use the system versions of most things.

* clean up apt cache
* add spack reuse option