### PR TITLE
Update hip copy path

### DIFF
--- a/ubuntu/hip/Dockerfile
+++ b/ubuntu/hip/Dockerfile
@@ -6,8 +6,8 @@ ARG hip_version
 ENV hip_version=$hip_version
 
 # Update package file to have patch
-COPY package.py /opt/spack/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
-COPY no_cyclades.patch /opt/spack/var/spack/repos/builtin/packages/llvm-amdgpu/no_cyclades.patch
+COPY ubuntu/hip/package.py /opt/spack/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+COPY ubuntu/hip/no_cyclades.patch /opt/spack/var/spack/repos/builtin/packages/llvm-amdgpu/no_cyclades.patch
 
 # We need this patch https://github.com/trws/spack/blob/2a54f77d7ebdfbbf131d43abd941ba7736a09737/var/spack/repos/builtin/packages/llvm/package.py#L342-L343
 RUN spack install --deprecated hip@${hip_version} rocprim@${hip_version}


### PR DESCRIPTION
Given the changes for the build to be relative to the root, this copy needs to be updated. I think we are using {prefix} that has -f Dockerfile but if we define it twice the second one might take. If needed we could tweak this in uptodate so it's not so buggy.