### PR TITLE
Shrink propagate, clang

### DIFF
--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install llvm with spack
 ARG llvm_version
 ENV llvm_version=$llvm_version
-ENV llvm_spec=llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly~compiler-rt build_type=Release
+ENV llvm_spec=llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly~compiler-rt build_type=MinSizeRel
 # these are safe here only because spack ignores them
 ENV COMPILER_NAME=clang
 ENV COMPILER_VERSION=$llvm_version

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -4,31 +4,24 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install llvm with spack
 ARG llvm_version
 ENV llvm_version=$llvm_version
-ENV llvm_spec=llvm@${llvm_version}+llvm_dylib+link_llvm_dylib+split_dwarf~lldb build_type=Release
+ENV llvm_spec=llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly~compiler-rt build_type=Release
+# these are safe here only because spack ignores them
+ENV COMPILER_NAME=clang
+ENV COMPILER_VERSION=$llvm_version
 ENV CC=/opt/view/bin/clang
 ENV CXX=/opt/view/bin/clang++
 ENV CPP=/opt/view/bin/clang-cpp
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
-      binutils-dev \
-      python3-dev \
-      && rm -rf /var/lib/apt/lists/* \
-      && apt-get clean
-
-RUN spack external find python perl binutils
-
-RUN spack -v install --reuse ${llvm_spec}
-# build compiler
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view ${llvm_spec} && \
-  spack compiler find
-
-# set default for spack
-RUN spack config add "packages:all:compiler:[clang@${llvm_version}]"
-
-# set system defaults
-RUN update-alternatives --install /usr/bin/cc cc ${CC} 50 \
+# build compiler and set defaults
+RUN spack external find hwloc ncurses \
+ && spack spec --reuse "${llvm_spec}" \
+ && spack -v install --reuse "${llvm_spec}" \
+ && spack compiler add \
+ && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
+ && update-alternatives --install /usr/bin/cc cc ${CC} 50 \
  && update-alternatives --install /usr/bin/c++ c++ ${CXX} 50 \
  && update-alternatives --install /usr/bin/cpp cpp ${CPP} 50 \
  && update-alternatives --install /usr/bin/c89 c89 ${CC} 50 \
  && update-alternatives --install /usr/bin/c99 c99 ${CC} 50
+
+


### PR DESCRIPTION
This should build a significantly smaller clang.  The actual llvm install totals about 1gb.