### PR TITLE
shrink propagate to gcc

### DIFF
--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -5,6 +5,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 ARG llvm_version
 ENV llvm_version=$llvm_version
 ENV llvm_spec="llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly+compiler-rt build_type=MinSizeRel" \
+    # these are safe here only because spack ignores them
     COMPILER_NAME=clang \
     COMPILER_VERSION=$llvm_version \
     CC=/opt/view/bin/clang \

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -5,7 +5,6 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 ARG llvm_version
 ENV llvm_version=$llvm_version
 ENV llvm_spec="llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly+compiler-rt build_type=MinSizeRel" \
-    # these are safe here only because spack ignores them
     COMPILER_NAME=clang \
     COMPILER_VERSION=$llvm_version \
     CC=/opt/view/bin/clang \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,30 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version
+ENV gcc_spec="gcc@${gcc_version}+strip~bootstrap+binutils languages=c,c++,fortran,go,lto"
+ENV COMPILER_NAME=gcc
+ENV COMPILER_VERSION=$gcc_version
+ENV CC=/opt/view/bin/gcc
+ENV CXX=/opt/view/bin/g++
+ENV FC=/opt/view/bin/gfortran
+ENV CPP=/opt/view/bin/cpp
 
-RUN spack install gcc@${gcc_version}
-RUN spack view --dependencies no symlink --ignore-conflicts /opt/view gcc@${gcc_version} && \
-  spack compiler find
+
+# build compiler and set defaults
+RUN spack external find hwloc ncurses \
+ && spack spec --reuse "${gcc_spec}" \
+ && spack -v install --deprecated --reuse "${gcc_spec}" \
+ && spack compiler add \
+ && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
+ && update-alternatives --install /usr/bin/cc cc ${CC} 50 \
+ && update-alternatives --install /usr/bin/c++ c++ ${CXX} 50 \
+ && update-alternatives --install /usr/bin/gcc gcc ${CC} 50 \
+ && update-alternatives --install /usr/bin/g++ g++ ${CXX} 50 \
+ && update-alternatives --install /usr/bin/gfortran gfortran ${FC} 50 \
+ && update-alternatives --install /usr/bin/f77 f77 ${FC} 50 \
+ && update-alternatives --install /usr/bin/f95 f95 ${FC} 50 \
+ && update-alternatives --install /usr/bin/cpp cpp ${CPP} 50 \
+ && update-alternatives --install /usr/bin/c89 c89 ${CC} 50 \
+ && update-alternatives --install /usr/bin/c99 c99 ${CC} 50
+
+

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version
-ENV gcc_spec="gcc@${gcc_version}+strip~bootstrap+binutils languages=c,c++,fortran,go,lto"
+ENV gcc_spec="gcc@${gcc_version}~bootstrap+binutils languages=c,c++,fortran,go,lto"
 ENV COMPILER_NAME=gcc
 ENV COMPILER_VERSION=$gcc_version
 ENV CC=/opt/view/bin/gcc

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version}~bootstrap+strip+binutils|languages=c,c++,fortran,lto|cflags=-Os -pipe|cxxflags=-Os -pipe" \
+    gcc_spec="gcc@${gcc_version}+bootstrap+strip+binutils languages=c,c++,fortran,lto" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \
@@ -12,13 +12,18 @@ ENV gcc_version=$gcc_version \
     FC=/opt/view/bin/gfortran \
     CPP=/opt/view/bin/cpp
 
+RUN apt-get -qq update \
+ && apt-get -qq install -y --no-install-recommends "texinfo" \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get clean
 
 # build compiler and set defaults
 # note the IFS to split the spec, spack can't tolerate a single-string spec with
 # multiple flags components apparently
-RUN spack external find hwloc ncurses \
- && IFS='|' spack spec --reuse ${gcc_spec} \
- && IFS='|' spack -v install --deprecated --reuse ${gcc_spec} \
+RUN spack external find hwloc ncurses texinfo \
+ && EXTRA_LANG=$(bash -c "[[ ${gcc_version} > 5 ]] && echo ',jit'" || true) \
+ && spack spec --reuse ${gcc_spec}$EXTRA_LANG "^binutils@2.38:" \
+ && spack -v install --deprecated --reuse ${gcc_spec} \
  && spack compiler add \
  && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
  && update-alternatives --install /usr/bin/cc cc ${CC} 50 \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version}~bootstrap languages=c,c++,fortran,go,lto" \
+    gcc_spec="gcc@${gcc_version} languages=c,c++,fortran,go,lto" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -3,8 +3,9 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 
 # Install gcc with spack
 ARG gcc_version
+ARG JOBS=2
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version}+bootstrap+strip+binutils languages=c,c++,fortran,lto" \
+    gcc_spec="gcc@${gcc_version}+bootstrap+strip+binutils languages=c,c++,fortran,lto,go" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \
@@ -13,17 +14,17 @@ ENV gcc_version=$gcc_version \
     CPP=/opt/view/bin/cpp
 
 RUN apt-get -qq update \
- && apt-get -qq install -y --no-install-recommends "texinfo" \
+ && apt-get -qq install -y --no-install-recommends texinfo gawk \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get clean
 
 # build compiler and set defaults
 # note the IFS to split the spec, spack can't tolerate a single-string spec with
 # multiple flags components apparently
-RUN spack external find hwloc ncurses texinfo \
+RUN spack external find hwloc ncurses texinfo gawk \
  && EXTRA_LANG=$(bash -c "[[ ${gcc_version} > 5 ]] && echo ',jit'" || true) \
  && spack spec --reuse ${gcc_spec}$EXTRA_LANG "^binutils@2.38:" \
- && spack -v install --deprecated --reuse ${gcc_spec} \
+ && spack -v install --jobs $JOBS --deprecated --reuse ${gcc_spec} \
  && spack compiler add \
  && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
  && update-alternatives --install /usr/bin/cc cc ${CC} 50 \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -3,14 +3,14 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 
 # Install gcc with spack
 ARG gcc_version
-ENV gcc_version=$gcc_version
-ENV gcc_spec="gcc@${gcc_version}~bootstrap+binutils languages=c,c++,fortran,go,lto"
-ENV COMPILER_NAME=gcc
-ENV COMPILER_VERSION=$gcc_version
-ENV CC=/opt/view/bin/gcc
-ENV CXX=/opt/view/bin/g++
-ENV FC=/opt/view/bin/gfortran
-ENV CPP=/opt/view/bin/cpp
+ENV gcc_version=$gcc_version \
+    gcc_spec="gcc@${gcc_version}~bootstrap+binutils languages=c,c++,fortran,go,lto" \
+    COMPILER_NAME=gcc \
+    COMPILER_VERSION=$gcc_version \
+    CC=/opt/view/bin/gcc \
+    CXX=/opt/view/bin/g++ \
+    FC=/opt/view/bin/gfortran \
+    CPP=/opt/view/bin/cpp
 
 
 # build compiler and set defaults

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 ARG gcc_version
 ARG JOBS=2
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version}+bootstrap+strip+binutils languages=c,c++,fortran,lto,go" \
+    gcc_spec="gcc@${gcc_version}+bootstrap+strip+binutils languages=c,c++,fortran,lto" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version} languages=c,c++,fortran,go,lto" \
+    gcc_spec="gcc@${gcc_version}~bootstrap+strip+binutils|languages=c,c++,fortran,lto|cflags=-Os -pipe|cxxflags=-Os -pipe" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \
@@ -14,9 +14,11 @@ ENV gcc_version=$gcc_version \
 
 
 # build compiler and set defaults
+# note the IFS to split the spec, spack can't tolerate a single-string spec with
+# multiple flags components apparently
 RUN spack external find hwloc ncurses \
- && spack spec --reuse "${gcc_spec}" \
- && spack -v install --deprecated --reuse "${gcc_spec}" \
+ && IFS='|' spack spec --reuse ${gcc_spec} \
+ && IFS='|' spack -v install --deprecated --reuse ${gcc_spec} \
  && spack compiler add \
  && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
  && update-alternatives --install /usr/bin/cc cc ${CC} 50 \

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install gcc with spack
 ARG gcc_version
 ENV gcc_version=$gcc_version \
-    gcc_spec="gcc@${gcc_version}~bootstrap+binutils languages=c,c++,fortran,go,lto" \
+    gcc_spec="gcc@${gcc_version}~bootstrap languages=c,c++,fortran,go,lto" \
     COMPILER_NAME=gcc \
     COMPILER_VERSION=$gcc_version \
     CC=/opt/view/bin/gcc \


### PR DESCRIPTION
And set the many, many alternatives.

This adds LTO and go support to gcc while removing two of the three default builds of gcc and stripping the debug info to shrink the container.