### PR TITLE
restore compiler-rt to support asan

### DIFF
--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/rse-ops/ubuntu:$ubuntu_version
 # Install llvm with spack
 ARG llvm_version
 ENV llvm_version=$llvm_version
-ENV llvm_spec="llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly~compiler-rt build_type=MinSizeRel" \
+ENV llvm_spec="llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~polly+compiler-rt build_type=MinSizeRel" \
     # these are safe here only because spack ignores them
     COMPILER_NAME=clang \
     COMPILER_VERSION=$llvm_version \


### PR DESCRIPTION
Turns out I made a mistake removing clang compiler-rt.  While we don't directly depend on it, asan does.