### PR TITLE
Bump actions versions, set-output to use GITHUB_OUTPUT

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -15,7 +15,8 @@ container_name=ghcr.io/rse-ops/${container}:${tag}
 docker pull ${container_name} || echo "Container $container_name does not exist yet"
 printf "docker build -f ${dockerfile} -t ${container_name} .\n"
 docker build -f ${dockerfile} -t ${container_name} .
-echo ::set-output name=container_uri::${container_name}
-echo ::set-output name=uri::ghcr.io/rse-ops/${container}
-echo ::set-output name=tag::${tag}
-echo ::set-output name=dockerfile_dir::${basedir}
+
+echo "container_uri=${container_name}" >> $GITHUB_OUTPUT
+echo "uri=ghcr.io/rse-ops/${container}" >> $GITHUB_OUTPUT
+echo "tag=${tag}" >> $GITHUB_OUTPUT
+echo "dockerfile_dir=${basedir}" >> $GITHUB_OUTPUT

--- a/.github/scripts/build_simple.sh
+++ b/.github/scripts/build_simple.sh
@@ -8,5 +8,6 @@ printf "Base directory is ${basedir}\n"
 # Get relative path to PWD and generate dashed name from it
 echo "${prefix} -t ${container} ."
 ${prefix} -f $filename -t ${container} .
-echo ::set-output name=uri::${container}
-echo ::set-output name=dockerfile_dir::${basedir}
+
+echo "uri=${container}" >> $GITHUB_OUTPUT
+echo "dockerfile_dir=${basedir}" >> $GITHUB_OUTPUT

--- a/.github/scripts/combine_results.sh
+++ b/.github/scripts/combine_results.sh
@@ -14,13 +14,13 @@ fi
 result=$(python -c "import json; print(json.loads('${result}') + json.loads('${result_scheduled}'))")
 if [[ "${result}" == "[]" ]]; then
   printf "The matrix is empty, will not trigger next workflow.\n"
-  echo "::set-output name=empty_matrix::true"
+  echo "empty_matrix=true" >> $GITHUB_OUTPUT
 else
   printf "The matrix is not empty, and we should continue on to the next workflow.\n"
-  echo "::set-output name=empty_matrix::false"
+  echo "empty_matrix=false" >> $GITHUB_OUTPUT
 fi
 echo ${result}
 
 # set for both workflows that use it
-echo "::set-output name=dockerfilelist_matrix::${result}"
-echo "::set-output name=dockerbuild_matrix::${result}"
+echo "dockerfilelist_matrix=${result}" >> $GITHUB_OUTPUT
+echo "dockerbuild_matrix=${result}" >> $GITHUB_OUTPUT

--- a/.github/scripts/prepare_paths.sh
+++ b/.github/scripts/prepare_paths.sh
@@ -24,4 +24,5 @@ echo ${parsed}
 if [[ "${parsed}" == "" ]]; then
     parsed="/does/not/exist/pathy"
 fi
-echo "::set-output name=parsed_files::${parsed}"
+
+echo "parsed_files=${parsed}" >> $GITHUB_OUTPUT

--- a/.github/scripts/relative_path.sh
+++ b/.github/scripts/relative_path.sh
@@ -5,4 +5,4 @@ set -e
 echo "Original path is $filename"
 relative=$(echo ${filename/\/github\/workspace\//})
 echo "Relative path is $relative"
-echo "::set-output name=relative_path::${relative}"
+echo "relative_path=${relative}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-matrices.yaml
+++ b/.github/workflows/build-matrices.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       # START PULL REQUEST / PUSH checkout and file derivation =======================
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: github.event_name != 'schedule'
       with:
          fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
       # END PULL REQUEST / PUSH checkout and file derivation =======================
 
       # START SCHEDULED checkout and file derivation =======================
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: github.event_name == 'schedule'      
       with:
          fetch-depth: 0
@@ -88,18 +88,18 @@ jobs:
     name: "Build ${{ matrix.result.container_name }}"
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: GHCR Login
       if: (github.event_name != 'pull_request')
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       
     - name: Make Space For Build
       run: |

--- a/.github/workflows/build-matrices.yaml
+++ b/.github/workflows/build-matrices.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Get changed files
       id: changed-files
       if: github.event_name != 'schedule'
-      uses: tj-actions/changed-files@32d6fb28f082f273420574e9de0a30be993bba58
+      uses: tj-actions/changed-files@aa52cfcd81f1a00a6bf1241a8cad6adec4d80638 # v33
       with:
         separator: " "
 

--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         if: github.event_name != 'schedule'
-        uses: tj-actions/changed-files@32d6fb28f082f273420574e9de0a30be993bba58       
+        uses: tj-actions/changed-files@aa52cfcd81f1a00a6bf1241a8cad6adec4d80638 # v33
         with:
           separator: " "
           files_ignore: .github*

--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -18,7 +18,6 @@ on:
     branches:
       - main
 
-
 jobs:
   update:
     name: Test Updated Dockerfiles
@@ -32,7 +31,7 @@ jobs:
       # START PULL REQUEST / PUSH checkout and file derivation =======================
       # Using git in the container to diff means we explicitly need to checkout a branch
       # if we use the default of this action we get a detached HEAD state.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name != 'schedule'
         with:
            fetch-depth: 0
@@ -63,7 +62,7 @@ jobs:
       # END PULL REQUEST / PUSH checkout and file derivation =======================
 
       # START SCHEDULED checkout and file derivation =======================
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'schedule'
         with:
            fetch-depth: 0
@@ -125,18 +124,18 @@ jobs:
     steps:
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: GHCR Login
       if: (github.event_name != 'pull_request')
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Make Space For Build
       run: |

--- a/ubuntu/hip/Dockerfile
+++ b/ubuntu/hip/Dockerfile
@@ -2,8 +2,6 @@ ARG hip_version
 ARG ubuntu_version
 FROM ghcr.io/rse-ops/hip-base-ubuntu-$ubuntu_version:llvm-amdgpu-${hip_version}
 
-# comment to trigger build
-
 # Install with spack
 ARG hip_version
 ENV hip_version=$hip_version


### PR DESCRIPTION
also update set-output to use new format to pipe into envar, per GitHub warnings in current action output!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>