### PR TITLE
Test fix to current bug

### DIFF
--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -15,7 +15,8 @@ ENV llvm_spec="llvm@${llvm_version}+llvm_dylib+link_llvm_dylib~split_dwarf~lldb~
 # build compiler and set defaults
 RUN spack external find hwloc ncurses \
  && spack spec --reuse "${llvm_spec}" \
- && spack -v install --reuse "${llvm_spec}" \
+ && spack add "${llvm_spec}" \
+ && spack -v install --reuse \
  && spack compiler add \
  && spack config add "packages:all:compiler:[${COMPILER_NAME}@${COMPILER_VERSION}]" \
  && update-alternatives --install /usr/bin/cc cc ${CC} 50 \


### PR DESCRIPTION
Some update of spack no longer allows the format we have, see https://github.com/rse-ops/docker-images/actions/runs/3425206991/jobs/5705770256#step:8:85.  I am attempting a fix by doing spack add, spack install